### PR TITLE
Added POST functionality for payment_types, and to complete orders

### DIFF
--- a/components/order/form-modal.js
+++ b/components/order/form-modal.js
@@ -14,6 +14,7 @@ export default function CompleteFormModal({ showModal, setShowModal, paymentType
         </select>
       </div>
       <>
+      {/* completeOrder is sent from cart.js module to this child component. It takes one argument, the id of a selected payment method */}
         <button className="button is-success" onClick={() => completeOrder(selectedPayment)}>Complete Order</button>
         <button className="button" onClick={() => setShowModal(false)}>Cancel</button>
       </>

--- a/components/payments/payment-modal.js
+++ b/components/payments/payment-modal.js
@@ -5,6 +5,7 @@ import Modal from "../modal"
 export default function AddPaymentModal({ showModal, setShowModal, addNewPayment }) {
   const merchantNameInput = useRef()
   const acctNumInput = useRef()
+  const expirationDate = useRef()
   return (
     <Modal showModal={showModal} setShowModal={setShowModal} title="Add New Payment Method">
       <>
@@ -20,13 +21,21 @@ export default function AddPaymentModal({ showModal, setShowModal, addNewPayment
           label="Account Number"
           refEl={acctNumInput}
         />
+        <Input
+          id="expirationDate"
+          type="text"
+          label="Expiration Date"
+          placeholder={new Date().toLocaleDateString()}
+          refEl={expirationDate}
+        />
       </>
       <>
         <button
           className="button is-success"
           onClick={() => addNewPayment({
-            acctNumber: acctNumInput.current.value,
-            merchant: merchantNameInput.current.value
+            account_number: acctNumInput.current.value,
+            merchant_name: merchantNameInput.current.value,
+            expiration_date: expirationDate.current.value.split("/").reverse().join("-")
           })}
         >Add Payment Method</button>
         <button className="button" onClick={() => setShowModal(false)}>Cancel</button>

--- a/components/product/detail.js
+++ b/components/product/detail.js
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router"
 import { useState, useRef } from "react"
-import { addProductToOrder, recommendProduct } from "../../data/products"
+import { addProductToCart, recommendProduct } from "../../data/products"
 import Modal from "../modal"
 import { Input } from "../form-elements"
 
@@ -12,7 +12,7 @@ export function Detail({ product, like, unlike }) {
 
 
   const addToCart = () => {
-    addProductToOrder(product.id).then(() => {
+    addProductToCart(product.id).then(() => {
       router.push('/cart')
     })
   }

--- a/data/orders.js
+++ b/data/orders.js
@@ -17,12 +17,12 @@ export function getOrders() {
 }
 
 export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
+  return fetchWithResponse(`orders/${orderId}`, {
     method: "PUT",
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ paymentTypeId }),
+    body: JSON.stringify({ payment_type: paymentTypeId }),
   });
 }

--- a/data/products.js
+++ b/data/products.js
@@ -30,12 +30,14 @@ export function getProductById(id) {
   })
 }
 
-export function addProductToOrder(id) {
-  return fetchWithResponse(`products/${id}/add_to_order`, {
+export function addProductToCart(id) {
+  return fetchWithResponse(`my-profile/cart`, {
     method: 'POST',
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
+      "Content-Type": "application/json",
+      Authorization: `Token ${localStorage.getItem('token')}`,
+    },
+    body: JSON.stringify({product_id: id})
   })
 }
 

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -32,6 +32,7 @@ export default function Cart() {
     })
   }, [])
 
+  // References cart from state. Function definition is sent to prop to CompleteFormModal
   const completeOrder = (paymentTypeId) => {
     completeCurrentOrder(cart.id, paymentTypeId).then(() => router.push('/my-orders'))
   }


### PR DESCRIPTION
This pull request aims to assist in the communication between the client-side and server-side of our app. The main issues in communication between the two is the data that was being sent was not what the server was expecting to store, and a change in routing. Our team has decided to use the `"/cart"` sub-route generate by Django REST framework when declaring a new action in a view-set. 
## Changes

- Added a new field to the `AddPaymentModal` component. We are tracking a payment method's expiration date, so when that date is met, we will no longer receive payments from that user's payment method. The input for this field is a text field, designed to look like a date-input. The return of which will be stored as date type according to Django datefield. 

- Changed key names of `payment_type` object being sent to the server. The server was expecting these names instead of `merchant` and `acctNumber`. 

- Renamed function name from `AddProductToOrder` to `AddProductToCart`. This is the endpoint that is being used, and reflects more clearly to the team what this function's responsibility is. 

- Configured `completeOrder` function to send a JSON stringed object instead of a stand-alone value to the database. The values are read by accessing the keyname. 

- Changed route in `data/products.js` to represent the sub-route generated by Django REST framework instead of routing the request to the `Cart` viewset in the server. Added to the request headers, authorization so that the authenticated user may send the request and receive a response if any. 

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/my-profile/cart` Creates a new product
(Keep in mind, the cart endpoint is not included in the registration of the route to the profile viewset, but is generated at the time that the request is sent. Any client-based service will need to include this endpoint).

```json
{
    "product_id":  1,
}
```

**Response**

HTTP/1.1 201 OK
No body is received by the client, but they will be redirected to their cart once they have clicked the `Add to Cart` button in the details section of a product.

**Request**

```json
{
    "merchant_name": {Enter Merchant Name in the associated input field},
    "account_number": {Enter an account number in the associated input field},
    "expiration_date": {Enter a string following the format MM/DD/YYYY} 
}
```
(Note: Zeroes do not have to be included before the month and day)

**Response**

HTTP/1.1 201 OK
No body is received by the client. Instead, the information they entered in the Modal form will be submitted to the server and re-fetched. It will appear after the form has been submitted on the same page. 
## Testing

## Related Issues

- Fixes #2 Products are added to the last order. During the development process, following the steps outlined in the issue ticket, I was not able to replicate the bug. It seems that once a user has completed an order, they are navigated to their order history, where the previous order appears. When the user adds a new product to their cart, a new cart is generated. 