### PR TITLE
Order History Details Not Displaying

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.13"

--- a/components/order/detail.js
+++ b/components/order/detail.js
@@ -2,16 +2,16 @@ import Table from "../table"
 
 export default function CartDetail({ cart, removeProduct }) {
   const headers = ['Product', 'Price', '']
-  const footers = ['Total', cart.total, '']
+  const footers = ['Total ', '$' + (cart.total_cost || 0), '']
 
   return (
     <Table headers={headers} footers={footers}>
       {
-        cart.products?.map(product => {
+        cart.lineitems?.map(lineitem => {
           return (
-            <tr key={product.id}>
-              <td>{product.name}</td>
-              <td>{product.price}</td>
+            <tr key={lineitem.id}>
+              <td>{lineitem.product.name}</td>
+              <td>${lineitem.product.price}</td>
               <td>
                 <span className="icon is-clickable" onClick={() => removeProduct(product.id)}>
                   <i className="fas fa-trash"></i>

--- a/components/order/detail.js
+++ b/components/order/detail.js
@@ -2,18 +2,18 @@ import Table from "../table"
 
 export default function CartDetail({ cart, removeProduct }) {
   const headers = ['Product', 'Price', '']
-  const footers = ['Total', cart.total, '']
+  const footers = ['Total ', '$' + (cart.total_cost || 0), '']
 
 
   
   return (
     <Table headers={headers} footers={footers}>
       {
-        cart.products?.map(product => {
+        cart.lineitems?.map(lineitem => {
           return (
-            <tr key={product.id}>
-              <td>{product.name}</td>
-              <td>{product.price}</td>
+            <tr key={lineitem.id}>
+              <td>{lineitem.product.name}</td>
+              <td>${lineitem.product.price}</td>
               <td>
                 <span className="icon is-clickable" onClick={() => removeProduct(product.id)}>
                   <i className="fas fa-trash"></i>

--- a/data/auth.js
+++ b/data/auth.js
@@ -21,7 +21,7 @@ export function register(user) {
 }
 
 export function getUserProfile() {
-  return fetchWithResponse('my-profile', {
+  return fetchWithResponse('profile', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
     }

--- a/data/orders.js
+++ b/data/orders.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse } from "./fetcher";
 
 export function getCart() {
-  return fetchWithResponse("cart", {
+  return fetchWithResponse("profile/cart", {
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
     },

--- a/data/products.js
+++ b/data/products.js
@@ -31,7 +31,7 @@ export function getProductById(id) {
 }
 
 export function addProductToCart(id) {
-  return fetchWithResponse(`cart`, {
+  return fetchWithResponse(`profile/cart`, {
     method: 'POST',
     headers: {
       "Content-Type": "application/json",

--- a/data/products.js
+++ b/data/products.js
@@ -31,7 +31,7 @@ export function getProductById(id) {
 }
 
 export function addProductToCart(id) {
-  return fetchWithResponse(`my-profile/cart`, {
+  return fetchWithResponse(`profile/cart`, {
     method: 'POST',
     headers: {
       "Content-Type": "application/json",

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -24,9 +24,9 @@ export default function Orders() {
           {
             orders.map((order) => (
               <tr key={order.id}>
-                <td>{order.completed_on}</td>
-                <td>${order.total}</td>
-                <td>{order.payment_type?.obscured_num}</td>
+                <td>{order.created_date}</td>
+                <td>${order.total}</td> 
+                <td>{order.payment_type?.merchant_name}</td>
               </tr>
             ))
           }

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -25,7 +25,7 @@ export default function Orders() {
             orders.map((order) => (
               <tr key={order.id}>
                 <td>{order.created_date}</td>
-                <td>${order.total}</td> 
+                <td>${order.total_cost.toFixed(2)}</td> 
                 <td>{order.payment_type?.merchant_name}</td>
               </tr>
             ))


### PR DESCRIPTION
When a user navigates to their orders, the correct amount of rows is displaying, but no information about the previous and open order were displaying. 

# Changes

- Formatted the footer array in `components/order/detail.js` to improve readability. Conditionally rendering the `total_cost` to 0 if a customer has not yet added any products to their cart. Otherwise, an error would be thrown that the `total_cost` property was not defined. 

- The mapping was targeting the correct array, but the property names of used in the client did not match the field names given in the API response. Changed the names to reflect the API response's.

- Changed the parameter name used in the mapping of line items, for clarity to the team and other developers about the object being mapped.   

- Changed the url in  `data/orders.js` function named `getCart()`. The API url was misconfiguered, targeting the incorrect viewset that handle the `GET` HTTP command. The same is true for the `addProductToCart()` function; it is being handled by the `Profile` viewset in the server which includes a `@cart` sub-route.

- The cart and order history are two different components, but suffered from similar issues. The `pages/my-orders.js` is responsible for rendering a customer's order history, not the cart itself. However, the key names used in the client-side of the web application were not the same at the key names given the response from the API. Changed them in the client to reflect API's response. 

Fixes #33 