### PR TITLE
Changed placeholder value for expiration date in create a payment

### DIFF
--- a/components/payments/payment-modal.js
+++ b/components/payments/payment-modal.js
@@ -25,7 +25,7 @@ export default function AddPaymentModal({ showModal, setShowModal, addNewPayment
           id="expirationDate"
           type="text"
           label="Expiration Date"
-          placeholder={new Date().toLocaleDateString()}
+          placeholder="DD/MM/YYYY"
           refEl={expirationDate}
         />
       </>


### PR DESCRIPTION
# Description

This pull request is a hot fix of a feature that was already working, but updating it for readability and clarity. 

# Changes

The changes made in this pull request is the placeholder value for the text input for the payment modal form. Originally, the placeholder was displaying "4/4/2025", or just the current date in a human readable form. However, in cases like these, it is unknown whether the first digit is the month or the day. So, instead, the placeholder should show the expected format to the user. It has been changed to "MM/DD/YYYY"

# Fixes

There is no associated issue ticket requesting this change, but when I was working in the backend to figure out why a payment method was not submitting, it was because I was submitting an improper date format. This should help a user clearly understand what date format is expected to be entered in this input. 