### PR TITLE
Fixed a bug that occurs on refresh of a product detail's component

### DIFF
--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -1,11 +1,16 @@
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
 import Layout from '../../../components/layout'
 import Navbar from '../../../components/navbar'
 import { Detail } from '../../../components/product/detail'
-import { Ratings } from '../../../components/rating/detail'
-import { getProductById, likeProduct, unLikeProduct } from '../../../data/products'
+import { getProductById, likeProduct, unLikeProduct } from '../../../data/products' 
 
+// Use dynamic import for Ratings component with SSR disabled
+const Ratings = dynamic(
+  () => import('../../../components/rating/detail').then(mod => mod.Ratings),
+  { ssr: false }
+)
 
 export default function ProductDetail() {
   const router = useRouter()


### PR DESCRIPTION
# What is the bug?

The bug is: when a user clicks on a product in a store. They are navigated to that product's details view. Everything works fine up until this point, but if they click the refresh button at the top-left of their browser, an error would be raised from NextJS. The error was a runtime error. The runtime error incorporated a ReferenceError that the `window` HTML element was not defined. This is due to server-side rendering of one particular component, `<Ratings />`. 

# Bug resolution

After finding the source, that this component was indeed causing the runtime error, we had to come up with a way that would allow this particular component be rendered client-side and not server-side because it is dependent upon an active browser with the window HTML already loaded, during server-side rendering, this element is unavailable to the `<Ratings />` component

# Changes made

All changes made were made in `pages/products/[id]/index.js` 

 - First, the original import of the Rating component function logic had to be removed. 
 - **NextJS** offers us dynamic rendering. We had to import that function and pass the original import path for Ratings as an argument to `dynamic`'s anonymous function. 
 - After passing the path to the `dynamic` function we modify Ratings `ssr` value (server-side rendering) to false. This is where the actual error that was being raised is handled. Declaring that the component should not be rendered on the server but on the client. 
 
 # Logic
  
 ```jsx
 // Use dynamic import for Ratings component with SSR disabled
const Ratings = dynamic(
  () => import('../../../components/rating/detail').then(mod => mod.Ratings),
  { ssr: false }
)
```

 # Issues
 Fixes #38 