### PR TITLE
Bugs when a user logs in or registers

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -4,7 +4,7 @@ import { useAppContext } from "../context/state";
 import { useRouter } from "next/router";
 
 export default function Navbar() {
-  const { token, profile } = useAppContext();
+  const { token, profile, setToken } = useAppContext();
   const hamburger = useRef();
   const navbar = useRef();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -62,6 +62,7 @@ export default function Navbar() {
             onClick={() => {
               localStorage.removeItem("token");
               setIsLoggedIn(false);
+              setToken("")
               router.push("/login");
             }}
           >

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -42,7 +42,7 @@ export default function Navbar() {
           <Link href="/profile" className="navbar-item">
             Profile
           </Link>
-          {profile.store ? (
+          {profile.store?.name ? (
             <>
               <Link className="navbar-item" href={`/stores/${profile.store.id}`}>
                 View Your Store

--- a/context/state.js
+++ b/context/state.js
@@ -2,21 +2,17 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { getUserProfile } from '../data/auth';
 import { useRouter } from "next/router"
 
+// Creates our context object.
 const AppContext = createContext();
 
 export function AppWrapper({ children }) {
   const [profile, setProfile] = useState({})
   const [token, setToken] = useState("")
   const router = useRouter()
-
-  useEffect(() => {
-    setToken(localStorage.getItem('token'))
-  }, [])
-
+  
   useEffect(() => {
     const authRoutes = ['/login', '/register']
     if (token) {
-      localStorage.setItem('token', token)
       if (!authRoutes.includes(router.pathname)) {
         getUserProfile().then((profileData) => {
           if (profileData) {
@@ -28,12 +24,14 @@ export function AppWrapper({ children }) {
   }, [token])
 
   return (
+    // The value prop stores functions and variables in context object. 
     <AppContext.Provider value={{ profile, token, setToken, setProfile }}>
       {children}
     </AppContext.Provider>
   );
 }
 
+// Encapsulates React hook, useContext, and context object in a custom hook
 export function useAppContext() {
   return useContext(AppContext);
 }

--- a/context/state.js
+++ b/context/state.js
@@ -9,16 +9,25 @@ export function AppWrapper({ children }) {
   const [profile, setProfile] = useState({})
   const [token, setToken] = useState("")
   const router = useRouter()
-  
+
+  // Useful for when a window is closed and a user opens a new session, still logged in
+  useEffect(() => {
+    setToken(localStorage.getItem("token"))
+  }, [])
+
   useEffect(() => {
     const authRoutes = ['/login', '/register']
     if (token) {
+      // Gets user profile for any route, not during authentication process
       if (!authRoutes.includes(router.pathname)) {
         getUserProfile().then((profileData) => {
           if (profileData) {
             setProfile(profileData)
           }
         })
+      }
+      else {
+        window.alert("There has been an issue retrieving your user profile.")
       }
     }
   }, [token])

--- a/pages/login.js
+++ b/pages/login.js
@@ -8,6 +8,7 @@ import { useAppContext } from "../context/state";
 import { login } from "../data/auth";
 
 export default function Login() {
+  // After storing the setToken function in context, we destructure it here
   const { setToken } = useAppContext();
   const username = useRef("");
   const password = useRef("");
@@ -22,7 +23,9 @@ export default function Login() {
 
     login(user).then((res) => {
       if (res.token) {
+        // Because we destructured the setToken function, we can update state here
         setToken(res.token);
+        localStorage.setItem('token', res.token);
         router.push("/");
       }
     });

--- a/pages/login.js
+++ b/pages/login.js
@@ -24,9 +24,8 @@ export default function Login() {
     login(user).then((res) => {
       if (res.token) {
         // Because we destructured the setToken function, we can update state here
-        setToken(res.token);
+        router.push("/").then(() => setToken(res.token));
         localStorage.setItem('token', res.token);
-        router.push("/");
       }
     });
   };

--- a/pages/register.js
+++ b/pages/register.js
@@ -35,6 +35,7 @@ export default function Register() {
     register(user).then((res) => {
       if (res.token) {
         setToken(res.token);
+        localStorage.setItem("token", res.token);
         router.push("/");
       }
     });


### PR DESCRIPTION
# Bug description

We were running into an issue where a user could log in or register, but their first attempt would always fail. This is mainly caused by the way that state was being updated in `context/state.js` and the `useEffect` in the self-same module executed. Sometimes, the state would be updated quickly enough to accommodate a user's login and sometimes not. 

# **Ch-Ch-Ch**-Changes 

- In `components/navbar.js` unpacked the `setToken` function from `appContext` to reset token to initial value after a user has logged out. Before this change, token state would remain even after a user had logged out and would cause issues when identifying a user properly. 

- Added the `.name` property to the condition in `components/navbar.js`. Some users may or may not have stores, but there is an initial object there with their id already associated with them. The id will always be available. So, instead, we decided to conditional render some nav-bar elements if one of these conditions are not null.

- Added a window alert to the user in case the process for GETting their user profile failed. 

- We need their token data as state and stored in localeStorage. This was originally being handled in the `state.js` module but is the root of problem with users unable to login without issue. Immediately after navigating the user to the home route, we will set their token. Before this change, the token was set in the auth routing. We do not want the token to be set at either the `"/login"` or `"/register"` route. We want their token to be set at the home route, after they have logged in. This is resolved by line 27 in `pages/login.js`.

- In order for a user to be navigated to the home route after registration, we set the token in localeStorage immediately after setting their new token state. 

# Fixes
- Fixes #54 