### PR TITLE
Updated API URL in data.js

### DIFF
--- a/data/stores.js
+++ b/data/stores.js
@@ -40,12 +40,13 @@ export function editStore(store) {
 }
 
 export function favoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/favorite`, {
+  return fetchWithoutResponse(`/profile/favorite`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
+    body: JSON.stringify({"store_id": storeId})
   })
 }
 


### PR DESCRIPTION
# Changes
After building out the `profile/favorite` subroute in the back-end, the front-end API URL fetch request needed to be updated as well so that the request body would be directed to the proper, expected location in the API for processing. 

The request body associated with this request is for creating new customer-to-store relationships in the database,  therefore, this request does need to include a body, and in this case, the required information needed on the body is the `id` of the store being favorited by a user. 

# Testing
To test that this API fetch is working properly:
- [ ] Navigate to the `Stores` tab in the Bangazon web application.
- [ ] Click the `Favorite` button located in the top-right of the screen.
- [ ] Navigate to your user profile
- [ ] The store that you have favorited will be shown under the subheading `Favorited Stores`

# Issue
This pull request completes the feature issue ticket #13.