### PR TITLE
Removed unnecessary useEffect. Accessed profile for liked products

### DIFF
--- a/data/products.js
+++ b/data/products.js
@@ -123,11 +123,4 @@ export function unLikeProduct(productId) {
   });
 }
 
-export function getLiked() {
-  return fetchWithResponse("products/liked", {
-    headers: {
-      Authorization: `Token ${localStorage.getItem("token")}`,
-    },
-  });
-}
 // YOOOOO SHARE BROWSER HEN_DAWG!!!

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -11,8 +11,6 @@ import { getLiked } from "../data/products"
 
 export default function Profile() {
   const { profile, setProfile } = useAppContext();
-  const [ likedProducts, setLikedProducts ] = useState([])
-
 
   useEffect(() => {
     getUserProfile().then((profileData) => {
@@ -21,14 +19,6 @@ export default function Profile() {
       }
     });
   }, []);
-
-  useEffect(() => {
-    getLiked().then(res => setLikedProducts(res))
-    
-
-  },[])
-
-
 
   return (
     <>
@@ -71,7 +61,7 @@ export default function Profile() {
 
       <CardLayout title="Products you've liked" width="is-full">
         <div className="columns is-multiline">
-          {likedProducts?.map((product) => (
+          {profile.liked_products.map((product) => (
             <ProductCard
               product={product}
               key={product.id}


### PR DESCRIPTION
Because we are now adding the products that a customer has liked to that customer's profile: we no longer need to make a separate fetch request for their liked products when displaying a customer-user's profile. 

# Changes

 - `data/products.js` Removed `getLiked()` function. This function was responsible for fetching the products that the authenticated user had liked, but we are now serializing the customer's profile to include these products on their profile instead, making this code no longer necessary.
 
 - `pages/profile.js` Removed the `useEFfect()` that was invoking `getLiked()`. Since the latter function is no longer necessary there is no need to keep the `useEffect()` making the call to that function. It has been removed. 
 
 - `pages/profile.js` Removed the global state variable that holding the customer's liked products. Now, the liked products is being held in the state variable `profile` for simpler access.
 
- Since the liked products are now being held in the profile. We must access the `profile` object and iterate through the array `liked_products`.

# Fixes
- Issue #63 