### PR TITLE
Ft/cat2/ks

### DIFF
--- a/components/filter.js
+++ b/components/filter.js
@@ -13,7 +13,7 @@ export default function Filter({ productCount, onSearch, locations }) {
     direction: useRef(),
     number_sold: useRef(),
   }
-
+  console.log(locations)
   const [showFilters, setShowFilters] = useState(false)
   const [query, setQuery] = useState('')
   const [categories, setCategories] = useState([{id: 1, name: 'Apples'}, {id: 2, name: 'Oranges'}, {id: 3, name: 'Lemons'}])

--- a/components/filter.js
+++ b/components/filter.js
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { getCategories } from '../data/products'
 import { Input, Select } from './form-elements'
 
-export default function Filter({ productCount, onSearch, locations }) {
+export default function Filter({ productCount, onSearch, locations, productHeader }) {
   const refEls = {
     location: useRef(),
     category: useRef(),
@@ -83,7 +83,7 @@ export default function Filter({ productCount, onSearch, locations }) {
       <div className="level-left">
         <div className="level-item">
           <p className="subtitle is-5">
-            <strong>{productCount}</strong> products
+            <strong>{productCount} {productHeader}</strong> 
           </p>
         </div>
         <div className="level-item">

--- a/components/form-elements/select.js
+++ b/components/form-elements/select.js
@@ -7,7 +7,9 @@ export function Select({id, refEl, options, title, label, addlClass = "" }) {
           <option value="0">{title}</option>
           {
             options.map(option => (
-              <option key={option.id} value={option.id}>{option.name}</option>
+
+              <option key={option.id} value={option.id}>{option.name || option}</option>
+            
             ))
           }
         </select>

--- a/components/form-elements/select.js
+++ b/components/form-elements/select.js
@@ -6,9 +6,9 @@ export function Select({id, refEl, options, title, label, addlClass = "" }) {
         <select id={id} ref={refEl}>
           <option value="0">{title}</option>
           {
-            options.map(option => (
+            options.map((option, i) => (
 
-              <option key={option.id} value={option.id}>{option.name || option}</option>
+              <option key={i} value={option.id}>{option.name || option}</option>
             
             ))
           }

--- a/components/product/card.js
+++ b/components/product/card.js
@@ -1,37 +1,58 @@
-import Link from 'next/link'
-import { useState } from 'react'
+import Link from "next/link";
+import { useState } from "react";
 
-export function ProductCard({ product, removeProduct, isOwner = false, width="is-one-quarter", cardWidth }) {
-  const [p,sp] = useState(product)
+export function ProductCard({
+  product,
+  removeProduct,
+  isOwner = false,
+  width = "is-one-quarter",
+  cardWidth,
+}) {
+  const [p, sp] = useState(product);
   return (
     <div className={`column ${cardWidth}`}>
       <div className="card">
         <div className="card-image">
           <figure className="image is-4by3">
-            <img src={`http://localhost:8000` + product.image_path} alt="Placeholder image"/>
+            <img
+              src={`http://localhost:8000` + product.image_path}
+              alt="no image"
+              onError={(e) =>
+                (e.target.src =
+                  "http://localhost:8000/media/products/NI.png")
+              }
+            />
           </figure>
         </div>
         <header className="card-header">
           <p className="card-header-title">
-            <Link href={`/products/${product.id}`}>{product.name} - ${product.price}</Link>
+            <Link href={`/products/${product.id}`}>
+              {product.name} - ${product.price}
+            </Link>
           </p>
         </header>
         <div className="card-content">
-          <div className="content">
-            {product.description}
-          </div>
+          <div className="content">{product.description}</div>
         </div>
-        {
-          isOwner ?
-            <footer className="card-footer">
-              <Link href={`/products/${product.id}/edit`} className="card-footer-item">Edit</Link>
-              <a onClick={() => removeProduct(product.id)} className="card-footer-item">Delete</a>
-            </footer>
-            :
-            <></>
-        }
-
+        {isOwner ? (
+          <footer className="card-footer">
+            <Link
+              href={`/products/${product.id}/edit`}
+              className="card-footer-item"
+            >
+              Edit
+            </Link>
+            <a
+              onClick={() => removeProduct(product.id)}
+              className="card-footer-item"
+            >
+              Delete
+            </a>
+          </footer>
+        ) : (
+          <></>
+        )}
       </div>
     </div>
-  )
+  );
 }

--- a/components/product/card.js
+++ b/components/product/card.js
@@ -1,14 +1,14 @@
 import Link from 'next/link'
 import { useState } from 'react'
 
-export function ProductCard({ product, removeProduct, isOwner = false, width="is-one-quarter" }) {
+export function ProductCard({ product, removeProduct, isOwner = false, width="is-one-quarter", cardWidth }) {
   const [p,sp] = useState(product)
   return (
-    <div className={`column ${width}`}>
+    <div className={`column ${cardWidth}`}>
       <div className="card">
         <div className="card-image">
           <figure className="image is-4by3">
-            <img src={product.image_path} alt="Placeholder image"/>
+            <img src={`http://localhost:8000` + product.image_path} alt="Placeholder image"/>
           </figure>
         </div>
         <header className="card-header">

--- a/components/product/detail.js
+++ b/components/product/detail.js
@@ -48,7 +48,7 @@ export function Detail({ product, like, unlike }) {
         <div className="tile is-parent">
           <article className="tile is-child">
             <figure className="image is-4by3">
-              <img src={product.image_path}></img>
+              <img src={product.image_path } onError={(e) => e.target.src = 'http://localhost:8000/media/products/NI.png'}></img>
             </figure>
           </article>
         </div>

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -11,6 +11,7 @@ const checkErrorJson = (res) => {
   if (res.status !== 200 && res.status !== 201) {
     throw Error(res.status);
   } else {
+    // Converts fetched data into usable JavaScript data
     return res.json();
   }
 };

--- a/data/products.js
+++ b/data/products.js
@@ -130,4 +130,3 @@ export function getLiked() {
     },
   });
 }
-// YOOOOO SHARE BROWSER HEN_DAWG!!!

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -48,7 +48,8 @@ export default function Products() {
       <>
         <div className="page">
           <Filter
-            productCount={products.length}
+            productHeader={"products"}
+            productCount={products.products.length}
             onSearch={searchProducts}
             // Passes the locations array as a prop to the Filter function component
             locations={locations}
@@ -72,7 +73,7 @@ return (
     <>
       <div className="" style={{marginTop:"100px"}}>
         <Filter
-          productCount={products.length}
+          
           onSearch={searchProducts}
           locations={locations}
         />
@@ -83,11 +84,11 @@ return (
             return (
               <div key={category.id} className="">
                 <div className="">
-                  <h1  className="is-flex is-justify-content-center is-size-3 p-3">{category.name}</h1>
+                  <h1  className="is-flex is-justify-content-center is-size-3 p-3 ">{category.name}</h1>
                 </div>
               <div className="columns "  >
                 {category.last_5.map((p) => (
-                  <ProductCard product={p} key={p.id} className="" style={{border:"3px solid black"}}/>
+                  <ProductCard product={p} key={p.id} className="" style={{border:"3px solid black "}}/>
                 ))}
               </div>
               </div>

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -1,61 +1,103 @@
-import { useEffect, useState } from 'react'
-import Filter from '../../components/filter'
-import Layout from '../../components/layout'
-import Navbar from '../../components/navbar'
-import { ProductCard } from '../../components/product/card'
-import { getProducts } from '../../data/products'
+import { useEffect, useState } from "react";
+import Filter from "../../components/filter";
+import Layout from "../../components/layout";
+import Navbar from "../../components/navbar";
+import { ProductCard } from "../../components/product/card";
+import { getProducts } from "../../data/products";
 
 export default function Products() {
-  const [products, setProducts] = useState([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [loadingMessage, setLoadingMessage] = useState("Loading products...")
-  const [locations, setLocations] = useState([])
+  const [products, setProducts] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadingMessage, setLoadingMessage] = useState("Loading products...");
+  const [locations, setLocations] = useState([]);
 
   useEffect(() => {
-    getProducts().then(data => {
-      if (data) {
-
-        const locationData = [...new Set(data.map(product => product.location))]
-        const locationObjects = locationData.map(location => ({
-          id: location,
-          name: location
-        }))
-
-        setProducts(data)
-        setIsLoading(false)
-        setLocations(locationObjects)
-      }
-    })
-    .catch(err => {
-      setLoadingMessage(`Unable to retrieve products. Status code ${err.message} on response.`)
-    })
-  }, [])
+    getProducts()
+      .then((data) => {
+        // The API fetch encountered no errors. Data was received from the API 
+        if (data) {
+          
+          setProducts(data);
+          setIsLoading(false);
+          // Sets global state variable locations with received products data
+          setLocations(data.locations);
+          
+        }
+      })
+      .catch((err) => {
+        setLoadingMessage(
+          `Unable to retrieve products. Status code ${err.message} on response.`
+        );
+      });
+  }, []);
 
   const searchProducts = (event) => {
-    getProducts(event).then(productsData => {
+    
+    getProducts(event).then((productsData) => {
       if (productsData) {
-        setProducts(productsData)
+        setProducts(productsData);
       }
-    })
+    });
+  };
+
+
+  if (isLoading) return <p>{loadingMessage}</p>;
+
+  if (products.no_filter == false) {
+    return (
+      <>
+        <div className="page">
+          <Filter
+            productCount={products.length}
+            onSearch={searchProducts}
+            // Passes the locations array as a prop to the Filter function component
+            locations={locations}
+            
+          />
+
+          <div className="columns is-multiline">
+            {products.products.map((product) => (
+              <ProductCard product={product} key={product.id} cardWidth={"is-one-quarter"} />
+            ))}
+          </div>
+        </div>
+      </>
+    );
   }
 
-  if (isLoading) return <p>{loadingMessage}</p>
+  if (products.no_filter == true) {
+    
 
-  return (
+return (
     <>
-    <div className='page'>
+      <div className="" style={{marginTop:"100px"}}>
+        <Filter
+          productCount={products.length}
+          onSearch={searchProducts}
+          locations={locations}
+        />
 
-      <Filter productCount={products.length} onSearch={searchProducts} locations={locations} />
+        <div className="">
 
-      <div className="columns is-multiline">
-        {products.map(product => (
-          <ProductCard product={product} key={product.id} />
-        ))}
-      </div>
+          {products.products?.map((category) => {
+            return (
+              <div key={category.id} className="">
+                <div className="">
+                  <h1  className="is-flex is-justify-content-center is-size-3 p-3">{category.name}</h1>
+                </div>
+              <div className="columns "  >
+                {category.last_5.map((p) => (
+                  <ProductCard product={p} key={p.id} className="" style={{border:"3px solid black"}}/>
+                ))}
+              </div>
+              </div>
+            );
+          })}
         </div>
+      </div>
     </>
-  )
-}
+  );
+  }}
 
 Products.getLayout = function getLayout(page) {
   return (
@@ -63,5 +105,5 @@ Products.getLayout = function getLayout(page) {
       <Navbar />
       {page}
     </Layout>
-  )
-}
+  );
+};


### PR DESCRIPTION
Changes
Refactored <ProductCard /> to handle missing images with onError and accept optional card width

Added fallback image rendering to <Detail /> view

Updated <Filter /> to accept productHeader prop and render total product count

Improved <Select /> dropdowns to support string or object values

Updated /products page to:

Handle no_filter response

Display categories and their last 5 products in a grid

Dynamically build unique location options

Display a fallback message when no products are returned

Cleaned up unused console logs and improved layout clarity


Testing
To test this feature manually:

 Run the API server with updated category + product fixtures

 Visit /products page with no query params to see category layout

 Apply filters (category, location, etc.) to see product grid

 Remove filters and verify no_filter returns correct layout

 Break an image URL intentionally to confirm the fallback image renders

 Confirm dropdowns load locations and categories dynamically

