### PR TITLE
Fixed a bug that would not retrieve a new registered user's profile

### DIFF
--- a/components/filter.js
+++ b/components/filter.js
@@ -13,7 +13,7 @@ export default function Filter({ productCount, onSearch, locations, productHeade
     direction: useRef(),
     number_sold: useRef(),
   }
-  console.log(locations)
+  
   const [showFilters, setShowFilters] = useState(false)
   const [query, setQuery] = useState('')
   const [categories, setCategories] = useState([{id: 1, name: 'Apples'}, {id: 2, name: 'Oranges'}, {id: 3, name: 'Lemons'}])

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -6,7 +6,6 @@ import { ProductCard } from "../components/product/card";
 import { StoreCard } from "../components/store/card";
 import { useAppContext } from "../context/state";
 import { getUserProfile } from "../data/auth";
-import { getLiked } from "../data/products"
 
 
 export default function Profile() {

--- a/pages/register.js
+++ b/pages/register.js
@@ -34,9 +34,8 @@ export default function Register() {
 
     register(user).then((res) => {
       if (res.token) {
-        setToken(res.token);
-        localStorage.setItem("token", res.token);
-        router.push("/");
+        router.push("/").then(() => setToken(res.token));
+        localStorage.setItem('token', res.token);
       }
     });
   };


### PR DESCRIPTION
Had a similar bug from the login process where a user would not reliably retrieve their profile after signing into the web application. This time, we were unable to retrieve a customer profile for a new registered user. The fix is the same as the fix for the previous issue. 

# Bug Overview

The main cause of the bug is that, we were setting our token during the `"/register"` authroute. This is not where we want to set the token, the token needs to be set once the registered user has been redirected to the landing page, route `"/"`. We currently have a system in place that does not allow for profile retrieval at ther `"/login"` or `"/register"` routes.

# Changes

In order to resolve this bug, we removed setting the authenticated user's token in the `"/register"` route. Instead, after we `pushed()`ed the user to the landing page, we would then set the token. Profile retrieval is dependent upon our user having a token; it is observing state change for when this object has been assigned in the `state.js` module. Once the user had pushed, they would no longer be at either auth route, but on the landing page. Allowing the profile retrieval process to fire and return their profile successfully. 

# Fixes

There is no related issue ticket at this time, this issue was found during testing. We knew where and what was causing the bug since we have had a similar issue during the login process. 