### PR TITLE
Reconfigured prop values to Ratings component and object properties

### DIFF
--- a/components/rating/detail.js
+++ b/components/rating/detail.js
@@ -7,7 +7,7 @@ export function Ratings({
   average_rating,
   refresh,
   ratings = [],
-  number_purchased,
+  number_sold,
   likes = [],
   productId,
 }) {
@@ -20,8 +20,8 @@ export function Ratings({
       <Header
         averageRating={average_rating}
         ratingsLen={ratings.length}
-        numberPurchased={number_purchased}
-        likesLength={likes.length}
+        numberPurchased={number_sold}
+        likesLength={likes}
       />
       <RatingsContainer ratings={ratings} saveRating={saveRating} />
     </div>

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -51,7 +51,7 @@ export default function ProductDetail() {
         <Detail product={product} like={like} unlike={unlike} />
         <Ratings
           refresh={refresh}
-          number_purchased={product.number_purchased}
+          number_sold={product.number_sold}
           ratings={product.ratings}
           productId={id}
           average_rating={product.avg_rating}


### PR DESCRIPTION
We were incorrectly accessing the data we needed to display the number of times a product was sold and the number of likes that a product had. 

# Changes

- The properties on the response body that tells us how many times a product has been purchased is called `number_sold` not `number_purchased` though they syntactically mean the same thing. 

- The serializer is not sending an array associated with the number of likes that a product has, but a raw integer. There is no need to try and capture the length of an array on this, we are performing this logic in the back-end of the web application

# Fixes

Issue #71 