### PR TITLE
Changed object property names, and optional chaining

### DIFF
--- a/pages/payments.js
+++ b/pages/payments.js
@@ -43,7 +43,7 @@ export default function Payments() {
             payments.map(payment => (
               <tr key={payment.id}>
                 <td>{payment.merchant_name}</td>
-                <td>{payment.obscured_num}</td>
+                <td>{payment.obscured_account_number}</td>
                 <td>
                   <span className="icon is-clickable" onClick={() => removePayment(payment.id)}>
                     <i className="fas fa-trash"></i>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -60,7 +60,7 @@ export default function Profile() {
 
       <CardLayout title="Products you've liked" width="is-full">
         <div className="columns is-multiline">
-          {profile.liked_products.map((product) => (
+          {profile.liked_products?.map((product) => (
             <ProductCard
               product={product}
               key={product.id}


### PR DESCRIPTION
There are a few small bugs that need to be addressed. When a customer recommends another customer a product, the price of the recommended and liked products would not show. This was due to improper access to object properties. It is also possible that a customer may not have any liked products, thus we need to optionally chain that property as it could be returned undefined.

# Changes

- Displayed a payment method's obscured card number instead of the full number. The full number was not displaying properly either.

- Added optional chaining to `liked_products` mapping. It is possible that a customer may not have liked any products. This would throw an error that the `liked_products` array was undefined. We do not want to show our customers that there has been issue with something that they have not interacted with yet.

# Fixes

There is no associated issues ticket for this bug, but was found during testing of the development branch. 